### PR TITLE
fix: resolve PostgreSQL boolean field null constraint violations

### DIFF
--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -456,10 +456,8 @@ export function createPostgreSqlConfig(): PostgreSqlConfig {
     retryDelay: 1000,
   };
 
-  // Add PostgreSQL-specific boolean column type mapping
-  (config as any).columnTypes = {
-    boolean: BOOLEAN_COLUMN_TYPES.postgres
-  };
+  // PostgreSQL uses native boolean type, no custom column type mapping needed
+  // The native boolean type works correctly with defaults
 
   return config;
 }

--- a/backend/src/entities/__tests__/entity-boolean-defaults.test.ts
+++ b/backend/src/entities/__tests__/entity-boolean-defaults.test.ts
@@ -1,0 +1,87 @@
+import { Team } from '../team.entity';
+import { TeamMember } from '../team-member.entity';
+
+describe('Entity Boolean Defaults', () => {
+  describe('Team Entity', () => {
+    it('should have correct boolean field configuration', () => {
+      const team = new Team();
+      
+      // The active field should be undefined initially (will be set by database default)
+      expect(team.active).toBeUndefined();
+    });
+
+    it('should allow setting boolean values', () => {
+      const team = new Team();
+      
+      team.active = true;
+      expect(team.active).toBe(true);
+      
+      team.active = false;
+      expect(team.active).toBe(false);
+    });
+  });
+
+  describe('TeamMember Entity', () => {
+    it('should have correct boolean field configuration', () => {
+      const teamMember = new TeamMember();
+      
+      // The active field should be undefined initially (will be set by database default)
+      expect(teamMember.active).toBeUndefined();
+    });
+
+    it('should allow setting boolean values', () => {
+      const teamMember = new TeamMember();
+      
+      teamMember.active = true;
+      expect(teamMember.active).toBe(true);
+      
+      teamMember.active = false;
+      expect(teamMember.active).toBe(false);
+    });
+  });
+
+  describe('Database Type Awareness', () => {
+    const originalDatabaseType = process.env.DATABASE_TYPE;
+
+    afterEach(() => {
+      if (originalDatabaseType) {
+        process.env.DATABASE_TYPE = originalDatabaseType;
+      } else {
+        delete process.env.DATABASE_TYPE;
+      }
+    });
+
+    it('should work with PostgreSQL database type', () => {
+      process.env.DATABASE_TYPE = 'postgresql';
+      
+      const team = new Team();
+      team.name = 'Test Team';
+      team.description = 'Test Description';
+      
+      expect(team.name).toBe('Test Team');
+      expect(team.description).toBe('Test Description');
+    });
+
+    it('should work with MySQL database type', () => {
+      process.env.DATABASE_TYPE = 'mysql';
+      
+      const team = new Team();
+      team.name = 'Test Team';
+      team.description = 'Test Description';
+      
+      expect(team.name).toBe('Test Team');
+      expect(team.description).toBe('Test Description');
+    });
+
+    it('should work with SQLite database type', () => {
+      process.env.DATABASE_TYPE = 'sqlite';
+      
+      const team = new Team();
+      team.name = 'Test Team';
+      team.description = 'Test Description';
+      
+      expect(team.name).toBe('Test Team');
+      expect(team.description).toBe('Test Description');
+    });
+  });
+});

--- a/backend/src/entities/team-member.entity.ts
+++ b/backend/src/entities/team-member.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
 import { TeamMemberSprintCapacity } from './team-member-sprint-capacity.entity';
 import { Team } from './team.entity';
-import { booleanTransformer } from '../utils/boolean.transformer';
+import { getConditionalBooleanTransformer } from '../utils/conditional-boolean-transformer';
 
 @Entity()
 export class TeamMember {
@@ -20,7 +20,7 @@ export class TeamMember {
   @Column({ 
     type: 'boolean', 
     default: true,
-    transformer: booleanTransformer
+    nullable: false
   })
   active: boolean;
 

--- a/backend/src/entities/team.entity.ts
+++ b/backend/src/entities/team.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { TeamMember } from './team-member.entity';
 import { Sprint } from './sprint.entity';
-import { booleanTransformer } from '../utils/boolean.transformer';
+import { getConditionalBooleanTransformer } from '../utils/conditional-boolean-transformer';
 
 @Entity()
 export class Team {
@@ -20,7 +20,8 @@ export class Team {
   @Column({ 
     type: 'boolean', 
     default: true,
-    transformer: booleanTransformer
+    nullable: false,
+    transformer: getConditionalBooleanTransformer()
   })
   active: boolean;
 

--- a/backend/src/team-member/__tests__/team-member-boolean-api.test.ts
+++ b/backend/src/team-member/__tests__/team-member-boolean-api.test.ts
@@ -34,9 +34,19 @@ describe('TeamMember Boolean API Integration Tests', () => {
   });
 
   beforeEach(async () => {
-    // Clean up test data
-    await teamMemberRepository.delete({});
-    await teamRepository.delete({});
+    // Clean up test data - disable foreign key checks temporarily for SQLite
+    if (dataSource.options.type === 'sqlite') {
+      await dataSource.query('PRAGMA foreign_keys = OFF');
+    }
+    
+    try {
+      await teamMemberRepository.clear();
+      await teamRepository.clear();
+    } finally {
+      if (dataSource.options.type === 'sqlite') {
+        await dataSource.query('PRAGMA foreign_keys = ON');
+      }
+    }
 
     // Create a test team for team member operations
     testTeam = await teamRepository.save({

--- a/backend/src/team/__tests__/team-boolean-api.test.ts
+++ b/backend/src/team/__tests__/team-boolean-api.test.ts
@@ -31,9 +31,19 @@ describe('Team Boolean API Integration Tests', () => {
   });
 
   beforeEach(async () => {
-    // Clean up test data
-    await dataSource.getRepository(TeamMember).delete({});
-    await teamRepository.delete({});
+    // Clean up test data - disable foreign key checks temporarily for SQLite
+    if (dataSource.options.type === 'sqlite') {
+      await dataSource.query('PRAGMA foreign_keys = OFF');
+    }
+    
+    try {
+      await dataSource.getRepository(TeamMember).clear();
+      await teamRepository.clear();
+    } finally {
+      if (dataSource.options.type === 'sqlite') {
+        await dataSource.query('PRAGMA foreign_keys = ON');
+      }
+    }
   });
 
   describe('POST /teams - Create Team with Boolean Fields', () => {

--- a/backend/src/utils/__tests__/database-aware-boolean.decorator.test.ts
+++ b/backend/src/utils/__tests__/database-aware-boolean.decorator.test.ts
@@ -1,0 +1,142 @@
+// Mock TypeORM Column decorator
+const mockColumn = jest.fn(() => jest.fn());
+jest.mock('typeorm', () => ({
+  Column: mockColumn,
+}));
+
+import { BooleanColumn } from '../database-aware-boolean.decorator';
+import { booleanTransformer } from '../boolean.transformer';
+
+describe('BooleanColumn Decorator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear environment variables
+    delete process.env.DATABASE_TYPE;
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_TYPE;
+  });
+
+  it('should apply transformer for MySQL database', () => {
+    process.env.DATABASE_TYPE = 'mysql';
+    
+    class TestEntity {
+      @BooleanColumn({ default: true })
+      active: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      default: true,
+      transformer: booleanTransformer,
+    });
+  });
+
+  it('should apply transformer for SQLite database', () => {
+    process.env.DATABASE_TYPE = 'sqlite';
+    
+    class TestEntity {
+      @BooleanColumn({ default: false })
+      enabled: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      default: false,
+      transformer: booleanTransformer,
+    });
+  });
+
+  it('should NOT apply transformer for PostgreSQL database', () => {
+    process.env.DATABASE_TYPE = 'postgresql';
+    
+    class TestEntity {
+      @BooleanColumn({ default: true })
+      active: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      default: true,
+    });
+  });
+
+  it('should NOT apply transformer for postgres database type', () => {
+    process.env.DATABASE_TYPE = 'postgres';
+    
+    class TestEntity {
+      @BooleanColumn({ nullable: true })
+      optional: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      nullable: true,
+    });
+  });
+
+  it('should default to MySQL behavior when DATABASE_TYPE is not set', () => {
+    // DATABASE_TYPE is not set, should default to mysql behavior
+    
+    class TestEntity {
+      @BooleanColumn({ default: true })
+      active: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      default: true,
+      transformer: booleanTransformer,
+    });
+  });
+
+  it('should handle case-insensitive database types', () => {
+    process.env.DATABASE_TYPE = 'POSTGRESQL';
+    
+    class TestEntity {
+      @BooleanColumn({ default: false })
+      active: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      default: false,
+    });
+  });
+
+  it('should merge provided options with database-specific configuration', () => {
+    process.env.DATABASE_TYPE = 'mysql';
+    
+    class TestEntity {
+      @BooleanColumn({ 
+        default: true,
+        nullable: false,
+        comment: 'Test boolean field'
+      })
+      active: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      default: true,
+      nullable: false,
+      comment: 'Test boolean field',
+      transformer: booleanTransformer,
+    });
+  });
+
+  it('should work with empty options', () => {
+    process.env.DATABASE_TYPE = 'sqlite';
+    
+    class TestEntity {
+      @BooleanColumn()
+      flag: boolean;
+    }
+
+    expect(mockColumn).toHaveBeenCalledWith({
+      type: 'boolean',
+      transformer: booleanTransformer,
+    });
+  });
+});

--- a/backend/src/utils/conditional-boolean-transformer.ts
+++ b/backend/src/utils/conditional-boolean-transformer.ts
@@ -1,0 +1,17 @@
+import { booleanTransformer } from './boolean.transformer';
+
+/**
+ * Returns the boolean transformer only for databases that need it (MySQL and SQLite).
+ * For PostgreSQL, returns undefined to use native boolean handling.
+ */
+export function getConditionalBooleanTransformer() {
+  const dbType = (process.env.DATABASE_TYPE || 'mysql').toLowerCase();
+  
+  // Only use transformer for MySQL and SQLite
+  if (dbType === 'mysql' || dbType === 'sqlite') {
+    return booleanTransformer;
+  }
+  
+  // For PostgreSQL, use native boolean handling
+  return undefined;
+}

--- a/backend/src/utils/database-aware-boolean.decorator.ts
+++ b/backend/src/utils/database-aware-boolean.decorator.ts
@@ -1,0 +1,30 @@
+import { Column, ColumnOptions } from 'typeorm';
+import { booleanTransformer } from './boolean.transformer';
+
+/**
+ * Database-aware boolean column decorator that applies the appropriate configuration
+ * based on the database type being used.
+ */
+export function BooleanColumn(options: Partial<ColumnOptions> = {}): PropertyDecorator {
+    return function (target: any, propertyKey: string | symbol) {
+        // Get the database type from environment or default to mysql
+        const dbType = (process.env.DATABASE_TYPE || 'mysql').toLowerCase();
+
+        // Determine if transformer is needed based on database type
+        const requiresTransformer = dbType === 'mysql' || dbType === 'sqlite';
+
+        // Create column options with appropriate configuration
+        const columnOptions: ColumnOptions = {
+            type: 'boolean',
+            ...options,
+        };
+
+        // Only add transformer for databases that need it (MySQL and SQLite)
+        if (requiresTransformer) {
+            columnOptions.transformer = booleanTransformer;
+        }
+
+        // Apply the column decorator
+        Column(columnOptions)(target, propertyKey);
+    };
+}


### PR DESCRIPTION
- Add conditional boolean transformer that only applies to MySQL/SQLite
- Remove transformer for PostgreSQL to use native boolean handling
- Fix entity boolean fields to properly handle database defaults
- Update test cleanup to handle foreign key constraints properly
- Ensure PostgreSQL boolean columns work with default values

Fixes issue where PostgreSQL was receiving null values for boolean fields with default values, causing NOT NULL constraint violations during team creation.