### PR TITLE
fix: configure Vercel deployment for React SPA routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "vercel-build": "npm run build",
     "preview": "vite preview",
     "start": "vite",
     "test": "vitest",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,35 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
+      "src": "backend/api/index.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/(health|sprints|team-members|routes|api-docs|swagger-json)/(.*)",
+      "destination": "/backend/api/index"
+    },
+    {
+      "source": "/(health|sprints|team-members|routes|api-docs|swagger-json)",
+      "destination": "/backend/api/index"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/frontend/index.html"
+    }
+  ],
+  "functions": {
+    "backend/api/index.ts": {
+      "maxDuration": 30
+    }
+  }
+}


### PR DESCRIPTION
- Add frontend build configuration to vercel.json
- Route /api/* to backend, all other routes to React app
- Add vercel-build script to frontend package.json
- Fix 404 errors on client-side routes in production